### PR TITLE
Fix audio playback errors and correct test expectation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ export default function App() {
   ]);
 
   // Menggunakan suara yang sama untuk semua aksi
-  const playSound = useSound("/public/sounds/minecraft_level_up.mp3");
+  const playSound = useSound("/sounds/minecraft_level_up.mp3");
 
   const prevCommunity = useRef(state.community.length);
   const prevPot = useRef(pot);

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -3,6 +3,6 @@ import App from './App';
 
 test('renders poker heading', () => {
   render(<App />);
-  const heading = screen.getByText(/Pyker \(React\)/i);
+  const heading = screen.getByText(/PokeReact/i);
   expect(heading).toBeInTheDocument();
 });

--- a/src/hooks/useSound.js
+++ b/src/hooks/useSound.js
@@ -1,23 +1,25 @@
 import { useRef } from "react";
 
 export default function useSound(url) {
-  const audioRef = useRef(null);
+  const audioRef = useRef();
 
-  // Memastikan hanya satu audio yang di-load
+  // Pastikan hanya membuat objek Audio sekali
   if (!audioRef.current) {
     audioRef.current = new Audio(url);
   }
 
   return () => {
     if (process.env.NODE_ENV === "test") return;
-    try {
-      // Cek apakah audio ada dan belum sedang dimainkan
-      if (audioRef.current) {
-        audioRef.current.play();
-      }
-    } catch (error) {
-      // Mengabaikan kesalahan jika ada
-      console.error("Failed to play sound:", error);
+
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    // Tangani promise play untuk menghindari "Uncaught (in promise)"
+    const playPromise = audio.play();
+    if (playPromise !== undefined) {
+      playPromise.catch(() => {
+        /* abaikan kesalahan pemutaran */
+      });
     }
   };
 }


### PR DESCRIPTION
## Summary
- handle audio playback promise to avoid uncaught errors
- use correct public audio path and adjust heading test

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ae660b88508322963d25e46be8d9bb