### PR TITLE
Improve poker table visuals and player interface

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,9 +18,19 @@ export default function App() {
     startNewHand,
     resetGame,
   } = usePokerEngine([
-    { name: "You", isBot: false },
-    { name: "Lucy", isBot: true, level: "normal" },
-    { name: "Carl", isBot: true, level: "hard" },
+    { name: "You", isBot: false, avatar: "/assets/others/dealer.png" },
+    {
+      name: "Lucy",
+      isBot: true,
+      level: "normal",
+      avatar: "/assets/others/github_icon.png",
+    },
+    {
+      name: "Carl",
+      isBot: true,
+      level: "hard",
+      avatar: "/assets/others/instagram_icon.png",
+    },
   ]);
 
   // Menggunakan suara yang sama untuk semua aksi
@@ -28,6 +38,15 @@ export default function App() {
 
   const prevCommunity = useRef(state.community.length);
   const prevPot = useRef(pot);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "test") return;
+    const bg = new Audio("/sounds/minecraft_level_up.mp3");
+    bg.loop = true;
+    bg.volume = 0.2;
+    bg.play().catch(() => {});
+    return () => bg.pause();
+  }, []);
 
   // Menggunakan suara saat Preflop
   useEffect(() => {

--- a/src/components/ActionBar.jsx
+++ b/src/components/ActionBar.jsx
@@ -1,14 +1,23 @@
 // src/components/ActionBar.jsx
 import React, { useState } from "react";
 
+const ICONS = {
+  fold: "/assets/buttons/fold.png",
+  call: "/assets/buttons/call.png",
+  check: "/assets/buttons/check.png",
+  bet: "/assets/buttons/bet.png",
+  raise: "/assets/buttons/raise.png",
+};
+
 export default function ActionBar({ actions, onAction }) {
   const [amount, setAmount] = useState(10);
 
-  const renderBtn = (label, handler, color) => (
+  const renderBtn = (label, handler, color, icon) => (
     <button
       onClick={handler}
-      className={`px-4 py-2 rounded text-white font-semibold shadow-md transition-transform hover:scale-105 ${color}`}
+      className={`flex items-center gap-2 px-5 py-2 rounded-full text-white text-lg font-semibold shadow-md bg-gradient-to-b ${color} transition-all duration-200 hover:scale-105 hover:shadow-xl`}
     >
+      <img src={icon} alt="" className="w-5 h-5" />
       {label}
     </button>
   );
@@ -21,14 +30,31 @@ export default function ActionBar({ actions, onAction }) {
   const fold = actions.find((a) => a.type === "fold");
 
   return (
-    <div className="mt-4 flex flex-wrap gap-3 items-center justify-center">
-      {fold && renderBtn("Fold", () => onAction("fold"), "bg-red-600 hover:bg-red-700")}
+    <div className="mt-4 flex flex-wrap gap-4 items-center justify-center">
+      {fold &&
+        renderBtn(
+          "Fold",
+          () => onAction("fold"),
+          "from-red-500 to-red-700",
+          ICONS.fold
+        )}
 
-      {check && renderBtn("Check", () => onAction("check"), "bg-gray-600 hover:bg-gray-700")}
+      {check &&
+        renderBtn(
+          "Check",
+          () => onAction("check"),
+          "from-gray-500 to-gray-700",
+          ICONS.check
+        )}
 
       {call && (
         <div className="flex flex-col items-center">
-          {renderBtn("Call", () => onAction("call"), "bg-green-600 hover:bg-green-700")}
+          {renderBtn(
+            "Call",
+            () => onAction("call"),
+            "from-green-500 to-green-700",
+            ICONS.call
+          )}
           <span className="text-xs mt-1">Call {call.amount}</span>
         </div>
       )}
@@ -46,7 +72,8 @@ export default function ActionBar({ actions, onAction }) {
           {renderBtn(
             check ? "Bet" : "Raise",
             () => onAction("bet", amount),
-            "bg-blue-600 hover:bg-blue-700"
+            "from-blue-500 to-blue-700",
+            check ? ICONS.bet : ICONS.raise
           )}
         </>
       )}

--- a/src/components/CardImg.jsx
+++ b/src/components/CardImg.jsx
@@ -12,16 +12,17 @@ function imgSrc(card) {
 export default function CardImg({ card, w = 72 }) {
   return (
     <motion.img
-      initial={{ y: -20, opacity: 0 }}
-      animate={{ y: 0, opacity: 1 }}
-      transition={{ duration: 0.3 }}
+      initial={{ rotateY: 90, opacity: 0 }}
+      animate={{ rotateY: 0, opacity: 1 }}
+      transition={{ duration: 0.5 }}
       src={imgSrc(card)}
       alt={card?.back ? "Back" : `${card?.rank ?? "?"}${card?.suit ?? ""}`}
       style={{
         width: w,
         height: "auto",
-        borderRadius: 8,
+        borderRadius: 12,
         border: "2px solid white",
+        boxShadow: "0 4px 8px rgba(0,0,0,0.5)",
       }}
     />
   );

--- a/src/components/PlayerSeat.jsx
+++ b/src/components/PlayerSeat.jsx
@@ -10,11 +10,22 @@ export default function PlayerSeat({
   isYou = false,
   isTurn = false,
   reveal = false,
+  round,
 }) {
   const showFace = isYou || reveal;
   const [c1, c2] = player.hand || [];
   const MAX_TIME = 30;
   const [timeLeft, setTimeLeft] = useState(MAX_TIME);
+  const [avatar, setAvatar] = useState(
+    player.avatar || "/assets/others/dealer.png"
+  );
+
+  const handleAvatarChange = (e) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setAvatar(URL.createObjectURL(file));
+    }
+  };
 
   useEffect(() => {
     if (!isTurn) {
@@ -31,19 +42,56 @@ export default function PlayerSeat({
   const comboName = showFace
     ? getHandName(player.hand || [], community || [])
     : "";
+  const statusText = player.folded
+    ? "Folded"
+    : isTurn
+    ? "Betting"
+    : "Waiting";
+  const statusColor = player.folded
+    ? "bg-gray-600"
+    : isTurn
+    ? "bg-green-600"
+    : "bg-blue-600";
   return (
     <div
       className={`p-3 min-w-[220px] rounded-xl text-white ${
         isTurn ? "bg-white/10 ring-2 ring-amber-300" : "bg-black/40"
-      }`}
+      } ${round !== "Showdown" && !isTurn ? "opacity-50" : ""}`}
     >
-      <div className="font-bold">
-        {player.name} {player.folded ? "(Fold)" : ""}
+      <div className="flex items-center gap-2">
+        <label className="relative cursor-pointer">
+          <img
+            src={avatar}
+            alt={player.name}
+            className="w-10 h-10 rounded-full border-2 border-white object-cover"
+          />
+          {isYou && (
+            <input
+              type="file"
+              onChange={handleAvatarChange}
+              className="absolute inset-0 opacity-0 cursor-pointer"
+            />
+          )}
+        </label>
+        <div className="font-bold flex-1">
+          {player.name} {player.folded ? "(Fold)" : ""}
+        </div>
+        <span
+          className={`text-xs font-bold px-2 py-0.5 rounded ${statusColor}`}
+        >
+          {statusText}
+        </span>
       </div>
-      <div className="text-xs opacity-80">
-        Chips: {player.chips} &nbsp; • &nbsp; Bet: {player.bet}
+      <div className="mt-1 flex items-center gap-2 text-sm opacity-90">
+        <img
+          src="/assets/others/bet.png"
+          alt="chips"
+          className="w-4 h-4 drop-shadow"
+        />
+        <span className="text-lg font-bold">{player.chips}</span>
+        <span className="text-xs">Bet: {player.bet}</span>
       </div>
-      <div className="mt-2 flex gap-2">
+      <div className="mt-2 flex gap-3">
         <CardImg card={showFace ? c1 : { back: true }} />
         <CardImg card={showFace ? c2 : { back: true }} />
       </div>

--- a/src/components/PokerTable.jsx
+++ b/src/components/PokerTable.jsx
@@ -11,7 +11,7 @@ export default function PokerTable({ state, pot, winners }) {
 
   return (
     <div className="p-4 text-white">
-      <div className="relative mx-auto max-w-4xl border border-gray-600 rounded-xl p-8 bg-gray-900/70 backdrop-blur-sm shadow-lg">
+      <div className="relative mx-auto max-w-4xl p-8 rounded-[50px] shadow-2xl bg-gradient-to-b from-green-700 via-green-800 to-green-900">
         <div className="flex justify-between text-sm md:text-base">
           <div>
             Round: <b>{round}</b>
@@ -20,14 +20,14 @@ export default function PokerTable({ state, pot, winners }) {
             key={pot}
             initial={{ scale: 0.8 }}
             animate={{ scale: 1 }}
-            className="text-lg font-semibold"
+            className="text-lg font-semibold bg-black/40 px-3 py-1 rounded shadow-[0_0_10px_rgba(251,191,36,0.5)]"
           >
             Pot: <b>{pot}</b>
           </motion.div>
         </div>
 
         {/* Community cards */}
-        <div className="flex gap-2 justify-center my-6">
+        <div className="flex gap-3 justify-center my-6">
           {[0, 1, 2, 3, 4].map((i) => (
             <CardImg key={i} card={community[i]} w={88} />
           ))}
@@ -35,7 +35,7 @@ export default function PokerTable({ state, pot, winners }) {
 
         {/* Players grid */}
         <div
-          className="grid gap-3"
+          className="grid gap-6"
           style={{ gridTemplateColumns: "repeat(auto-fit, minmax(230px,1fr))" }}
         >
           {players.map((p, i) => (
@@ -45,6 +45,7 @@ export default function PokerTable({ state, pot, winners }) {
               community={community}
               isYou={i === 0}
               isTurn={i === currentPlayer && round !== "Showdown" && !p.folded}
+              round={round}
               reveal={revealEveryone}
             />
           ))}

--- a/src/core/models.js
+++ b/src/core/models.js
@@ -80,11 +80,12 @@ function distributePot(state) {
 
 export default class Game {
   constructor(players = []) {
-    // players input: [{ name, isBot?, level? }]
+    // players input: [{ name, isBot?, level?, avatar? }]
     this.templatePlayers = players.map((p) => ({
       name: p.name,
       isBot: !!p.isBot,
       level: p.level || "easy",
+      avatar: p.avatar || "/assets/others/dealer.png",
     }));
     this.dealerIndex = 0;
   }
@@ -99,6 +100,7 @@ export default class Game {
         name: p.name,
         isBot: p.isBot,
         level: p.level,
+        avatar: p.avatar,
         chips: 1000,
         bet: 0,
         folded: false,


### PR DESCRIPTION
## Summary
- Add avatar support and status indicators for each player with optional upload
- Restyle poker table with gradients, card flips and glowing pot
- Modernize action buttons with icons and smooth gradients; add ambient background music

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ae68bf07bc832285272ff294869433