### PR TITLE
Improve poker UI/UX layout and controls

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -102,11 +102,16 @@ export default function App() {
 
         <PokerTable state={state} pot={pot} winners={winners} />
 
-        {state.currentPlayer === 0 &&
-          status === "playing" &&
-          !state.players[0].folded && (
-            <ActionBar actions={availableActions} onAction={handleAction} />
-          )}
+          <ActionBar
+            actions={
+              state.currentPlayer === 0 &&
+              status === "playing" &&
+              !state.players[0].folded
+                ? availableActions
+                : []
+            }
+            onAction={handleAction}
+          />
 
         {status !== "playing" && winners.length > 0 && (
           <WinnerModal

--- a/src/components/ActionBar.jsx
+++ b/src/components/ActionBar.jsx
@@ -1,82 +1,67 @@
 // src/components/ActionBar.jsx
 import React, { useState } from "react";
 
-const ICONS = {
-  fold: "/assets/buttons/fold.png",
-  call: "/assets/buttons/call.png",
-  check: "/assets/buttons/check.png",
-  bet: "/assets/buttons/bet.png",
-  raise: "/assets/buttons/raise.png",
-};
-
-export default function ActionBar({ actions, onAction }) {
+export default function ActionBar({ actions = [], onAction }) {
   const [amount, setAmount] = useState(10);
 
-  const renderBtn = (label, handler, color, icon) => (
+  const renderBtn = (label, handler, color, disabled) => (
     <button
       onClick={handler}
-      className={`flex items-center gap-2 px-5 py-2 rounded-full text-white text-lg font-semibold shadow-md bg-gradient-to-b ${color} transition-all duration-200 hover:scale-105 hover:shadow-xl`}
+      disabled={disabled}
+      className={`px-5 py-2 border-2 rounded text-lg font-semibold transition-all duration-300 ease-in-out ${
+        disabled
+          ? "bg-gray-500 border-gray-600 text-gray-300 cursor-not-allowed opacity-60"
+          : `${color} text-white hover:brightness-110`
+      }`}
     >
-      <img src={icon} alt="" className="w-5 h-5" />
       {label}
     </button>
   );
-
-  if (!actions || !actions.length) return null;
 
   const hasBet = actions.find((a) => a.type === "bet");
   const call = actions.find((a) => a.type === "call");
   const check = actions.find((a) => a.type === "check");
   const fold = actions.find((a) => a.type === "fold");
 
+  const callOrCheck = call
+    ? { label: "Call", disabled: false }
+    : check
+    ? { label: "Check", disabled: false }
+    : { label: "Call/Check", disabled: true };
+
   return (
     <div className="mt-4 flex flex-wrap gap-4 items-center justify-center">
-      {fold &&
-        renderBtn(
-          "Fold",
-          () => onAction("fold"),
-          "from-red-500 to-red-700",
-          ICONS.fold
-        )}
+      {renderBtn("Fold", () => onAction("fold"), "bg-red-600 border-red-700", !fold)}
 
-      {check &&
-        renderBtn(
-          "Check",
-          () => onAction("check"),
-          "from-gray-500 to-gray-700",
-          ICONS.check
+      <div className="flex flex-col items-center">
+        {renderBtn(
+          callOrCheck.label,
+          () => onAction(call ? "call" : "check"),
+          "bg-green-600 border-green-700",
+          callOrCheck.disabled
         )}
-
-      {call && (
-        <div className="flex flex-col items-center">
-          {renderBtn(
-            "Call",
-            () => onAction("call"),
-            "from-green-500 to-green-700",
-            ICONS.call
-          )}
+        {call && (
           <span className="text-xs mt-1">Call {call.amount}</span>
-        </div>
-      )}
+        )}
+      </div>
 
-      {hasBet && (
-        <>
-          <input
-            type="number"
-            value={amount}
-            min={hasBet.min ?? 1}
-            max={hasBet.max ?? 9999}
-            onChange={(e) => setAmount(parseInt(e.target.value || "0", 10))}
-            className="w-24 p-1 rounded text-black"
-          />
-          {renderBtn(
-            check ? "Bet" : "Raise",
-            () => onAction("bet", amount),
-            "from-blue-500 to-blue-700",
-            check ? ICONS.bet : ICONS.raise
-          )}
-        </>
-      )}
+      <div className="flex items-center gap-2">
+        <input
+          type="number"
+          value={amount}
+          min={hasBet?.min ?? 1}
+          max={hasBet?.max ?? 9999}
+          onChange={(e) => setAmount(parseInt(e.target.value || "0", 10))}
+          disabled={!hasBet}
+          className="w-24 p-1 border rounded text-black disabled:bg-gray-200 disabled:text-gray-500 transition-colors duration-300 ease-in-out"
+        />
+        {renderBtn(
+          check ? "Bet" : "Raise",
+          () => onAction("bet", amount),
+          "bg-blue-600 border-blue-700",
+          !hasBet
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/CardImg.jsx
+++ b/src/components/CardImg.jsx
@@ -14,7 +14,7 @@ export default function CardImg({ card, w = 72 }) {
     <motion.img
       initial={{ rotateY: 90, opacity: 0 }}
       animate={{ rotateY: 0, opacity: 1 }}
-      transition={{ duration: 0.5 }}
+      transition={{ duration: 0.5, ease: "easeInOut" }}
       src={imgSrc(card)}
       alt={card?.back ? "Back" : `${card?.rank ?? "?"}${card?.suit ?? ""}`}
       style={{

--- a/src/components/PlayerSeat.jsx
+++ b/src/components/PlayerSeat.jsx
@@ -54,7 +54,7 @@ export default function PlayerSeat({
     : "bg-blue-600";
   return (
     <div
-      className={`p-3 min-w-[220px] rounded-xl text-white ${
+      className={`p-3 min-w-[220px] rounded-xl text-white transition-all duration-300 ease-in-out ${
         isTurn ? "bg-white/10 ring-2 ring-amber-300" : "bg-black/40"
       } ${round !== "Showdown" && !isTurn ? "opacity-50" : ""}`}
     >
@@ -102,7 +102,7 @@ export default function PlayerSeat({
         <div className="h-2 bg-white/30 rounded overflow-hidden">
           <motion.div
             animate={{ width: `${(timeLeft / MAX_TIME) * 100}%` }}
-            transition={{ ease: "linear", duration: 1 }}
+            transition={{ ease: "easeInOut", duration: 1 }}
             className="h-full bg-amber-300"
           />
         </div>

--- a/src/components/PokerTable.jsx
+++ b/src/components/PokerTable.jsx
@@ -20,6 +20,7 @@ export default function PokerTable({ state, pot, winners }) {
             key={pot}
             initial={{ scale: 0.8 }}
             animate={{ scale: 1 }}
+            transition={{ ease: "easeInOut", duration: 0.3 }}
             className="text-lg font-semibold bg-black/40 px-3 py-1 rounded shadow-[0_0_10px_rgba(251,191,36,0.5)]"
           >
             Pot: <b>{pot}</b>
@@ -33,22 +34,61 @@ export default function PokerTable({ state, pot, winners }) {
           ))}
         </div>
 
-        {/* Players grid */}
-        <div
-          className="grid gap-6"
-          style={{ gridTemplateColumns: "repeat(auto-fit, minmax(230px,1fr))" }}
-        >
-          {players.map((p, i) => (
+        {/* Players layout */}
+        <div className="relative mt-6 h-[260px]">
+          {/* Player (you) at bottom center */}
+          <div className="absolute bottom-0 left-1/2 -translate-x-1/2">
             <PlayerSeat
-              key={i}
-              player={p}
+              player={players[0]}
               community={community}
-              isYou={i === 0}
-              isTurn={i === currentPlayer && round !== "Showdown" && !p.folded}
+              isYou
+              isTurn={
+                0 === currentPlayer && round !== "Showdown" && !players[0].folded
+              }
               round={round}
               reveal={revealEveryone}
             />
-          ))}
+          </div>
+
+          {/* Bots on the sides */}
+          <div className="absolute top-0 left-0 flex flex-col gap-4">
+            {players.slice(1, 1 + Math.ceil((players.length - 1) / 2)).map(
+              (p, idx) => (
+                <PlayerSeat
+                  key={idx + 1}
+                  player={p}
+                  community={community}
+                  isTurn={
+                    idx + 1 === currentPlayer &&
+                    round !== "Showdown" &&
+                    !p.folded
+                  }
+                  round={round}
+                  reveal={revealEveryone}
+                />
+              )
+            )}
+          </div>
+
+          <div className="absolute top-0 right-0 flex flex-col gap-4 items-end">
+            {players
+              .slice(1 + Math.ceil((players.length - 1) / 2))
+              .map((p, idx) => (
+                <PlayerSeat
+                  key={idx + 1 + Math.ceil((players.length - 1) / 2)}
+                  player={p}
+                  community={community}
+                  isTurn={
+                    idx + 1 + Math.ceil((players.length - 1) / 2) ===
+                      currentPlayer &&
+                    round !== "Showdown" &&
+                    !p.folded
+                  }
+                  round={round}
+                  reveal={revealEveryone}
+                />
+              ))}
+          </div>
         </div>
 
         {/* Winners */}


### PR DESCRIPTION
## Summary
- Keep Fold/Call/Raise buttons visible with clearer rectangular styling
- Reposition seats so the player is centered at the bottom and bots sit on the sides
- Smooth card, pot and timer transitions using ease-in-out animations

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ae6de08e308322a5e17ae9f2b69f82