### PR TITLE
Add action indicators and compact poker table

### DIFF
--- a/src/components/PlayerSeat.jsx
+++ b/src/components/PlayerSeat.jsx
@@ -54,7 +54,7 @@ export default function PlayerSeat({
     : "bg-blue-600";
   return (
     <div
-      className={`p-3 min-w-[220px] rounded-xl text-white transition-all duration-300 ease-in-out ${
+      className={`p-2 min-w-[180px] rounded-xl text-white transition-all duration-300 ease-in-out ${
         isTurn ? "bg-white/10 ring-2 ring-amber-300" : "bg-black/40"
       } ${round !== "Showdown" && !isTurn ? "opacity-50" : ""}`}
     >
@@ -91,14 +91,19 @@ export default function PlayerSeat({
         <span className="text-lg font-bold">{player.chips}</span>
         <span className="text-xs">Bet: {player.bet}</span>
       </div>
-      <div className="mt-2 flex gap-3">
-        <CardImg card={showFace ? c1 : { back: true }} />
-        <CardImg card={showFace ? c2 : { back: true }} />
+      {player.lastAction && (
+        <div className="mt-1 text-xs italic opacity-80">
+          Last: {player.lastAction}
+        </div>
+      )}
+      <div className="mt-2 flex gap-2">
+        <CardImg card={showFace ? c1 : { back: true }} w={60} />
+        <CardImg card={showFace ? c2 : { back: true }} w={60} />
       </div>
       {showFace && (
         <div className="mt-1 text-xs text-center">{comboName}</div>
       )}
-      <div className="mt-3">
+      <div className="mt-2">
         <div className="h-2 bg-white/30 rounded overflow-hidden">
           <motion.div
             animate={{ width: `${(timeLeft / MAX_TIME) * 100}%` }}

--- a/src/components/PokerTable.jsx
+++ b/src/components/PokerTable.jsx
@@ -10,8 +10,8 @@ export default function PokerTable({ state, pot, winners }) {
   const revealEveryone = round === "Showdown";
 
   return (
-    <div className="p-4 text-white">
-      <div className="relative mx-auto max-w-4xl p-8 rounded-[50px] shadow-2xl bg-gradient-to-b from-green-700 via-green-800 to-green-900">
+    <div className="p-2 text-white">
+      <div className="relative mx-auto max-w-4xl p-4 rounded-[30px] shadow-xl bg-transparent">
         <div className="flex justify-between text-sm md:text-base">
           <div>
             Round: <b>{round}</b>
@@ -28,14 +28,14 @@ export default function PokerTable({ state, pot, winners }) {
         </div>
 
         {/* Community cards */}
-        <div className="flex gap-3 justify-center my-6">
+        <div className="flex gap-2 justify-center my-4">
           {[0, 1, 2, 3, 4].map((i) => (
-            <CardImg key={i} card={community[i]} w={88} />
+            <CardImg key={i} card={community[i]} w={72} />
           ))}
         </div>
 
         {/* Players layout */}
-        <div className="relative mt-6 h-[260px]">
+        <div className="relative mt-4 h-[220px]">
           {/* Player (you) at bottom center */}
           <div className="absolute bottom-0 left-1/2 -translate-x-1/2">
             <PlayerSeat


### PR DESCRIPTION
## Summary
- show last action (bet/raise/check) for each player
- compact table layout with transparent background and smaller cards
- track and reset player actions each round

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae6faeeb84832292340e471c6df72c