### PR TITLE
Refine UI and limit level-up sound to winners

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 // src/App.js
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 import usePokerEngine from "./hooks/usePokerEngine";
 import PokerTable from "./components/PokerTable";
 import ActionBar from "./components/ActionBar";
@@ -14,7 +14,7 @@ export default function App() {
     status,
     winners,
     availableActions,
-    handleAction: rawHandleAction,
+    handleAction,
     startNewHand,
     resetGame,
   } = usePokerEngine([
@@ -33,64 +33,14 @@ export default function App() {
     },
   ]);
 
-  // Menggunakan suara yang sama untuk semua aksi
-  const playSound = useSound("/sounds/minecraft_level_up.mp3");
-
-  const prevCommunity = useRef(state.community.length);
-  const prevPot = useRef(pot);
+  // Suara untuk pemenang
+  const playWinnerSound = useSound("/sounds/minecraft_level_up.mp3");
 
   useEffect(() => {
-    if (process.env.NODE_ENV === "test") return;
-    const bg = new Audio("/sounds/minecraft_level_up.mp3");
-    bg.loop = true;
-    bg.volume = 0.2;
-    bg.play().catch(() => {});
-    return () => bg.pause();
-  }, []);
-
-  // Menggunakan suara saat Preflop
-  useEffect(() => {
-    if (state.round === "Preflop" && state.community.length === 0) {
-      playSound();
+    if (winners.length > 0 && status !== "playing") {
+      playWinnerSound();
     }
-  }, [state.round, state.community.length, playSound]);
-
-  // Menggunakan suara saat Showdown
-  useEffect(() => {
-    if (status === "showdown") {
-      playSound();
-    }
-  }, [status, playSound]);
-
-  // Menggunakan suara saat ada perubahan kartu komunitas
-  useEffect(() => {
-    if (
-      prevCommunity.current < state.community.length &&
-      state.community.length > 0
-    ) {
-      playSound();
-    }
-    prevCommunity.current = state.community.length;
-  }, [state.community.length, playSound]);
-
-  // Menggunakan suara saat pot berubah
-  useEffect(() => {
-    if (prevPot.current !== pot) {
-      playSound();
-      prevPot.current = pot;
-    }
-  }, [pot, playSound]);
-
-  // Menambahkan suara untuk tindakan (bet, raise, call, fold, check)
-  const handleAction = useCallback(
-    (action, amount) => {
-      if (["bet", "raise", "call", "fold", "check"].includes(action)) {
-        playSound();
-      }
-      rawHandleAction(action, amount);
-    },
-    [rawHandleAction, playSound]
-  );
+  }, [winners, status, playWinnerSound]);
 
   return (
     <div className="min-h-screen">

--- a/src/components/OutOfChipsModal.js
+++ b/src/components/OutOfChipsModal.js
@@ -3,19 +3,19 @@ import React from "react";
 export default function OutOfChipsModal({ onRestart, onExit }) {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-50">
-      <div className="bg-white text-black rounded-lg p-6 shadow-xl w-96 text-center">
+      <div className="bg-[rgba(0,0,0,0.8)] text-[#e5e7eb] rounded-lg p-6 w-96 text-center border border-black shadow-[0_0_0_2px_#fff,0_0_0_4px_#000]">
         <h2 className="text-2xl font-bold mb-4">Saldo chip Anda habis</h2>
         <p className="mb-4">Apakah Anda ingin memulai permainan dari awal?</p>
         <div className="flex justify-center gap-4">
           <button
             onClick={onRestart}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+            className="px-4 py-2 bg-blue-600 border border-blue-700 text-[#e5e7eb] rounded-lg hover:brightness-110 shadow-[0_0_0_2px_#fff,0_0_0_4px_#000]"
           >
             Mulai Ulang
           </button>
           <button
             onClick={onExit}
-            className="px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700"
+            className="px-4 py-2 bg-gray-600 border border-gray-700 text-[#e5e7eb] rounded-lg hover:brightness-110 shadow-[0_0_0_2px_#fff,0_0_0_4px_#000]"
           >
             Keluar
           </button>

--- a/src/components/PlayerSeat.jsx
+++ b/src/components/PlayerSeat.jsx
@@ -50,8 +50,8 @@ export default function PlayerSeat({
     : "bg-blue-600";
   return (
     <div
-      className={`p-2 min-w-[180px] rounded-xl text-white transition-all duration-300 ease-in-out ${
-        isTurn ? "bg-white/10 ring-2 ring-white" : "bg-black/40"
+      className={`p-2 min-w-[180px] rounded-xl transition-all duration-300 ease-in-out border border-black shadow-[0_0_0_2px_#fff,0_0_0_4px_#000] text-[#e5e7eb] bg-[rgba(0,0,0,0.3)] ${
+        isTurn ? "ring-2 ring-white" : ""
       } ${round !== "Showdown" && !isTurn ? "opacity-50" : ""}`}
     >
       <div className="flex items-center gap-2">
@@ -59,7 +59,7 @@ export default function PlayerSeat({
           <img
             src={avatar}
             alt={player.name}
-            className="w-10 h-10 rounded-full border-2 border-white object-cover"
+            className="w-10 h-10 rounded-full border border-black shadow-[0_0_0_2px_#fff,0_0_0_4px_#000] object-cover"
           />
           {isYou && (
             <input
@@ -83,7 +83,9 @@ export default function PlayerSeat({
           className="w-4 h-4 drop-shadow"
         />
         <span className="text-lg font-bold">{player.chips}</span>
-        <span className="text-xs">Bet: {player.bet}</span>
+        {player.bet > 0 && (
+          <span className="text-xs">Bet: {player.bet}</span>
+        )}
       </div>
       {player.lastAction && (
         <div className="mt-1 text-xs italic opacity-80">

--- a/src/components/WinnerModal.js
+++ b/src/components/WinnerModal.js
@@ -5,18 +5,18 @@ import React from "react";
 export default function WinnerModal({ winners, onRestart }) {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-50">
-      <div className="bg-white text-black rounded-lg p-6 shadow-xl w-96 text-center">
+      <div className="bg-[rgba(0,0,0,0.8)] text-[#e5e7eb] rounded-lg p-6 w-96 text-center border border-black shadow-[0_0_0_2px_#fff,0_0_0_4px_#000]">
         <h2 className="text-2xl font-bold mb-4">Pemenang Ronde</h2>
         <ul className="mb-4">
           {winners.map((winner, idx) => (
-            <li key={idx} className="text-lg font-semibold text-green-700">
+            <li key={idx} className="text-lg font-semibold text-green-400">
               {winner}
             </li>
           ))}
         </ul>
         <button
           onClick={onRestart}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          className="px-4 py-2 bg-blue-600 border border-blue-700 text-[#e5e7eb] rounded-lg hover:brightness-110 shadow-[0_0_0_2px_#fff,0_0_0_4px_#000]"
         >
           Main Lagi
         </button>


### PR DESCRIPTION
## Summary
- streamline dark theme styling across player cards and modals
- fix player card bet display to avoid showing zero
- play minecraft_level_up.mp3 only when winners are revealed

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aeea5441f48322ae108ec02ffd4d19