### PR TITLE
Show last player actions without waiting indicator

### DIFF
--- a/src/components/PlayerSeat.jsx
+++ b/src/components/PlayerSeat.jsx
@@ -42,18 +42,18 @@ export default function PlayerSeat({
   const comboName = showFace
     ? getHandName(player.hand || [], community || [])
     : "";
-  const actionStatusMap = {
-    check: "Checking",
-    call: "Calling",
-    raise: "Raising",
-    bet: "Betting",
-    fold: "Folded",
+  const getStatusText = () => {
+    if (player.folded) return "Fold";
+    if (player.lastAction === "bet" || player.lastAction === "raise") {
+      return `${player.lastAction === "bet" ? "Bet" : "Raise"} ${
+        player.lastActionAmount ?? 0
+      }`;
+    }
+    if (player.lastAction === "call") return "Call";
+    if (player.lastAction === "check") return "Check";
+    return "";
   };
-  const statusText = player.folded
-    ? "Folded"
-    : isTurn
-    ? "Betting"
-    : actionStatusMap[player.lastAction] || "Waiting";
+  const statusText = getStatusText();
   const statusColor = player.folded
     ? "bg-gray-600"
     : isTurn
@@ -81,11 +81,13 @@ export default function PlayerSeat({
           )}
         </label>
         <div className="font-bold flex-1">{player.name}</div>
-        <span
-          className={`text-xs font-bold px-2 py-0.5 rounded ${statusColor}`}
-        >
-          {statusText}
-        </span>
+        {statusText && (
+          <span
+            className={`text-xs font-bold px-2 py-0.5 rounded ${statusColor}`}
+          >
+            {statusText}
+          </span>
+        )}
       </div>
       <div className="mt-1 flex items-center gap-2 text-sm opacity-90">
         <img

--- a/src/core/models.js
+++ b/src/core/models.js
@@ -137,26 +137,28 @@ export default class Game {
     let dealerIndex = this.dealerIndex;
 
     if (!prevState) {
-      players = this.templatePlayers.map((p) => ({
-        name: p.name,
-        isBot: p.isBot,
-        level: p.level,
-        avatar: p.avatar,
-        chips: 1000,
-        bet: 0,
-        folded: false,
-        hand: [deck.pop(), deck.pop()],
-        lastAction: null,
-      }));
+        players = this.templatePlayers.map((p) => ({
+          name: p.name,
+          isBot: p.isBot,
+          level: p.level,
+          avatar: p.avatar,
+          chips: 1000,
+          bet: 0,
+          folded: false,
+          hand: [deck.pop(), deck.pop()],
+          lastAction: null,
+          lastActionAmount: 0,
+        }));
       dealerIndex = 0;
     } else {
-      players = prevState.players.map((p) => ({
-        ...p,
-        bet: 0,
-        folded: false,
-        hand: [deck.pop(), deck.pop()],
-        lastAction: null,
-      }));
+        players = prevState.players.map((p) => ({
+          ...p,
+          bet: 0,
+          folded: false,
+          hand: [deck.pop(), deck.pop()],
+          lastAction: null,
+          lastActionAmount: 0,
+        }));
       dealerIndex = (prevState.dealerIndex + 1) % players.length;
     }
 
@@ -289,20 +291,24 @@ export default class Game {
     if (action === "fold") {
       p.folded = true;
       p.lastAction = "fold";
+      p.lastActionAmount = 0;
     } else if (action === "check") {
       p.lastAction = "check";
+      p.lastActionAmount = 0;
     } else if (action === "call") {
       const need = toCallBefore;
       const pay = Math.min(need, p.chips);
       p.chips -= pay;
       p.bet += pay;
       p.lastAction = "call";
+      p.lastActionAmount = pay;
     } else if (action === "bet") {
       const total = toCallBefore + (amount || 0);
       const pay = Math.min(total, p.chips);
       p.chips -= pay;
       p.bet += pay;
       p.lastAction = toCallBefore > 0 ? "raise" : "bet";
+      p.lastActionAmount = pay;
     }
 
     if (countActive(s.players) === 1) {
@@ -310,6 +316,7 @@ export default class Game {
       s.players.forEach((pl) => {
         pl.bet = 0;
         pl.lastAction = null;
+        pl.lastActionAmount = 0;
       });
       s.round = "Showdown";
       s.winners = this.checkWinners(s);
@@ -323,6 +330,7 @@ export default class Game {
       s.players.forEach((pl) => {
         pl.bet = 0;
         pl.lastAction = null;
+        pl.lastActionAmount = 0;
       });
 
       if (s.round === "Preflop") {


### PR DESCRIPTION
## Summary
- Show each player's last move, including bet or raise amounts
- Track and reset bet amounts for actions in game state
- Remove waiting label from player seats

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68aeef7d487c83229fcf637c06b7952c