### PR TITLE
Fix check handling and modernize UI

### DIFF
--- a/src/components/ActionBar.jsx
+++ b/src/components/ActionBar.jsx
@@ -8,10 +8,10 @@ export default function ActionBar({ actions = [], onAction }) {
     <button
       onClick={handler}
       disabled={disabled}
-      className={`px-5 py-2 border-2 rounded text-lg font-semibold transition-all duration-300 ease-in-out ${
+      className={`px-4 py-2 rounded-xl font-semibold text-white shadow-md transition-colors ${
         disabled
-          ? "bg-gray-500 border-gray-600 text-gray-300 cursor-not-allowed opacity-60"
-          : `${color} text-white hover:brightness-110`
+          ? "opacity-50 cursor-not-allowed"
+          : `${color} hover:brightness-110`
       }`}
     >
       {label}
@@ -30,22 +30,15 @@ export default function ActionBar({ actions = [], onAction }) {
     : { label: "Call/Check", disabled: true };
 
   return (
-    <div className="mt-4 flex flex-wrap gap-4 items-center justify-center">
-      {renderBtn(
-        "Fold",
-        () => onAction("fold"),
-        "bg-red-600 border-red-700 text-[#e5e7eb] shadow-[0_0_0_2px_#fff,0_0_0_4px_#000]",
-        !fold
-      )}
+    <div className="mt-6 flex flex-wrap items-center justify-center gap-4">
+      {renderBtn("Fold", () => onAction("fold"), "bg-red-600", !fold)}
 
-      <div className="flex flex-col items-center">
-        {renderBtn(
-          `${call ? `Call ${call.amount}` : callOrCheck.label}`,
-          () => onAction(call ? "call" : "check"),
-          "bg-green-600 border-green-700 text-[#e5e7eb] shadow-[0_0_0_2px_#fff,0_0_0_4px_#000]",
-          callOrCheck.disabled
-        )}
-      </div>
+      {renderBtn(
+        `${call ? `Call ${call.amount}` : callOrCheck.label}`,
+        () => onAction(call ? "call" : "check"),
+        "bg-green-600",
+        callOrCheck.disabled
+      )}
 
       <div className="flex items-center gap-2">
         <input
@@ -55,12 +48,12 @@ export default function ActionBar({ actions = [], onAction }) {
           max={hasBet?.max ?? 9999}
           onChange={(e) => setAmount(parseInt(e.target.value || "0", 10))}
           disabled={!hasBet}
-          className="w-24 p-1 border border-black rounded text-[#e5e7eb] bg-[rgba(0,0,0,0.3)] disabled:bg-gray-200 disabled:text-gray-500 transition-colors duration-300 ease-in-out shadow-[0_0_0_2px_#fff,0_0_0_4px_#000]"
+          className="w-24 p-1 rounded border border-gray-500 bg-gray-800 text-white transition-colors disabled:bg-gray-700 disabled:text-gray-400"
         />
         {renderBtn(
           check ? "Bet" : "Raise",
           () => onAction("bet", amount),
-          "bg-blue-600 border-blue-700 text-[#e5e7eb] shadow-[0_0_0_2px_#fff,0_0_0_4px_#000]",
+          "bg-blue-600",
           !hasBet
         )}
       </div>

--- a/src/components/PlayerSeat.jsx
+++ b/src/components/PlayerSeat.jsx
@@ -61,7 +61,7 @@ export default function PlayerSeat({
     : "bg-blue-600";
   return (
     <div
-      className={`p-2 min-w-[180px] rounded-xl transition-all duration-300 ease-in-out border border-black shadow-[0_0_0_2px_#fff,0_0_0_4px_#000] text-[#e5e7eb] bg-[rgba(0,0,0,0.3)] ${
+      className={`p-2 min-w-[180px] rounded-xl transition-all duration-300 ease-in-out border border-black shadow-[0_0_0_2px_#fff,0_0_0_4px_#000] bg-black/40 text-gray-100 ${
         isTurn ? "ring-2 ring-white" : ""
       } ${round !== "Showdown" && !isTurn ? "opacity-50" : ""}`}
     >
@@ -106,11 +106,11 @@ export default function PlayerSeat({
       </div>
       {showFace && <div className="mt-1 text-xs text-center">{comboName}</div>}
       <div className="mt-2">
-        <div className="h-2 bg-white/30 rounded overflow-hidden">
+        <div className="h-2 rounded bg-gray-700 overflow-hidden">
           <motion.div
             animate={{ width: `${(timeLeft / MAX_TIME) * 100}%` }}
             transition={{ ease: "easeInOut", duration: 1 }}
-            className="h-full bg-[rgb(229,231,235)]"
+            className="h-full bg-green-400"
           />
         </div>
         <div className="mt-1 text-xs text-center">{timeLeft}s</div>

--- a/src/core/models.js
+++ b/src/core/models.js
@@ -75,6 +75,8 @@ function allActiveMatchedBet(players) {
   let target = null;
   for (const p of players) {
     if (p.folded) continue;
+    // Semua pemain aktif harus sudah melakukan aksi terlebih dahulu
+    if (p.lastAction === null) return false;
     if (target === null) target = p.bet;
     if (p.bet !== target) return false;
   }


### PR DESCRIPTION
## Summary
- Prevent round from skipping on initial check by requiring all active players to act before progression
- Refresh action bar styling for consistent modern look
- Tidy player seat with clearer timer bar

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aef1bd20208322870234df2c21655e