### PR TITLE
Handle no active players in turn rotation

### DIFF
--- a/src/core/models.js
+++ b/src/core/models.js
@@ -55,6 +55,8 @@ function nextAliveIndex(players, from) {
   if (!Array.isArray(players)) {
     throw new Error("nextAliveIndex expects players array");
   }
+  const active = players.filter((p) => !p.folded && p.chips > 0);
+  if (active.length === 0) return -1;
   const n = players.length;
   let idx = (from + 1) % n;
   while (players[idx].folded || players[idx].chips === 0) {
@@ -366,7 +368,8 @@ export default class Game {
     }
 
     if (!s.endgame && s.round !== "Showdown") {
-      s.currentPlayer = nextAliveIndex(s.players, s.currentPlayer);
+      const nextIdx = nextAliveIndex(s.players, s.currentPlayer);
+      s.currentPlayer = nextIdx !== -1 ? nextIdx : -1;
     }
 
     return s;


### PR DESCRIPTION
## Summary
- Return `-1` from `nextAliveIndex` when no players can act
- Gracefully handle sentinel return in `Game.applyAction`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68af06a47c60832292d62b3f74c42724