### PR TITLE
Handle side pots and all-in distribution

### DIFF
--- a/src/core/sidepot.test.js
+++ b/src/core/sidepot.test.js
@@ -1,0 +1,65 @@
+import { awardPots } from "./models";
+
+test("handles side pots with multiple all-ins", () => {
+  const state = {
+    players: [
+      {
+        name: "P1",
+        chips: 0,
+        bet: 0,
+        totalBet: 50,
+        folded: false,
+        hand: [
+          { rank: "A", suit: "S" },
+          { rank: "A", suit: "H" },
+        ],
+        lastAction: null,
+        lastActionAmount: 0,
+      },
+      {
+        name: "P2",
+        chips: 0,
+        bet: 0,
+        totalBet: 100,
+        folded: false,
+        hand: [
+          { rank: "K", suit: "S" },
+          { rank: "K", suit: "H" },
+        ],
+        lastAction: null,
+        lastActionAmount: 0,
+      },
+      {
+        name: "P3",
+        chips: 0,
+        bet: 0,
+        totalBet: 200,
+        folded: false,
+        hand: [
+          { rank: "Q", suit: "S" },
+          { rank: "Q", suit: "H" },
+        ],
+        lastAction: null,
+        lastActionAmount: 0,
+      },
+    ],
+    community: [
+      { rank: "2", suit: "C" },
+      { rank: "7", suit: "D" },
+      { rank: "9", suit: "H" },
+      { rank: "J", suit: "S" },
+      { rank: "3", suit: "C" },
+    ],
+    pot: 350,
+    winners: [],
+  };
+
+  awardPots(state);
+
+  expect(state.players[0].chips).toBe(150); // main pot
+  expect(state.players[1].chips).toBe(100); // side pot
+  expect(state.players[2].chips).toBe(100); // final side pot
+  expect(state.pot).toBe(0);
+  expect(new Set(state.winners)).toEqual(new Set([0, 1, 2]));
+});
+


### PR DESCRIPTION
## Summary
- track each player's total bet and compute main/side pots accordingly
- award each pot to eligible winners during showdown
- add test covering multi-player all-in side pot scenario

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68af06aaab548322b2c06c07f54ed24e