### PR TITLE
Validate bet amounts and clamp actions

### DIFF
--- a/src/components/ActionBar.jsx
+++ b/src/components/ActionBar.jsx
@@ -2,7 +2,8 @@
 import React, { useState } from "react";
 
 export default function ActionBar({ actions = [], onAction }) {
-  const [amount, setAmount] = useState(10);
+  // keep raw input value to allow validation and user editing
+  const [amount, setAmount] = useState("10");
 
   const renderBtn = (label, handler, color, disabled) => (
     <button
@@ -22,6 +23,11 @@ export default function ActionBar({ actions = [], onAction }) {
   const call = actions.find((a) => a.type === "call");
   const check = actions.find((a) => a.type === "check");
   const fold = actions.find((a) => a.type === "fold");
+
+  const min = hasBet?.min ?? 1;
+  const max = hasBet?.max ?? 9999;
+  const numericAmount = parseInt(amount, 10);
+  const isValidAmount = !isNaN(numericAmount) && numericAmount >= min;
 
   const callOrCheck = call
     ? { label: "Call", disabled: false }
@@ -44,19 +50,25 @@ export default function ActionBar({ actions = [], onAction }) {
         <input
           type="number"
           value={amount}
-          min={hasBet?.min ?? 1}
-          max={hasBet?.max ?? 9999}
-          onChange={(e) => setAmount(parseInt(e.target.value || "0", 10))}
+          min={min}
+          max={max}
+          onChange={(e) => setAmount(e.target.value)}
           disabled={!hasBet}
           className="w-24 p-1 rounded border border-gray-500 bg-gray-800 text-white transition-colors disabled:bg-gray-700 disabled:text-gray-400"
         />
         {renderBtn(
           check ? "Bet" : "Raise",
-          () => onAction("bet", amount),
+          () => {
+            const clamped = Math.min(Math.max(numericAmount, min), max);
+            onAction("bet", clamped);
+          },
           "bg-blue-600",
-          !hasBet
+          !hasBet || !isValidAmount
         )}
       </div>
+      {!isValidAmount && hasBet && (
+        <p className="text-red-500 text-sm w-full text-center">Enter a valid amount ≥ {min}</p>
+      )}
     </div>
   );
 }

--- a/src/components/ActionPanel.js
+++ b/src/components/ActionPanel.js
@@ -8,7 +8,8 @@ export default function ActionPanel({
   handleAction,
   status,
 }) {
-  const [betAmount, setBetAmount] = useState(0);
+  // store raw input to validate
+  const [betAmount, setBetAmount] = useState("");
 
   if (status !== "CHOICE") return null;
 
@@ -18,22 +19,39 @@ export default function ActionPanel({
         {availableActions.map((action, idx) => {
           if (Array.isArray(action)) {
             const [act, range] = action;
+            const min = range[0];
+            const max = range[1];
+            const numericBet = parseInt(betAmount, 10);
+            const isValid = !isNaN(numericBet) && numericBet >= min;
             return (
-              <div key={idx} className="flex items-center gap-2">
-                <input
-                  type="number"
-                  min={range[0]}
-                  max={range[1]}
-                  value={betAmount}
-                  onChange={(e) => setBetAmount(Number(e.target.value))}
-                  className="p-1 rounded text-black w-20"
-                />
-                <button
-                  onClick={() => handleAction(act, betAmount, range)}
-                  className="px-4 py-2 bg-blue-600 rounded-lg hover:bg-blue-700 shadow transition transform hover:scale-105"
-                >
-                  Bet/Raise
-                </button>
+              <div key={idx} className="flex flex-col items-center gap-2">
+                <div className="flex items-center gap-2">
+                  <input
+                    type="number"
+                    min={min}
+                    max={max}
+                    value={betAmount}
+                    onChange={(e) => setBetAmount(e.target.value)}
+                    className="p-1 rounded text-black w-20"
+                  />
+                  <button
+                    onClick={() => {
+                      const clamped = Math.min(Math.max(numericBet, min), max);
+                      handleAction(act, clamped, range);
+                    }}
+                    disabled={!isValid}
+                    className={`px-4 py-2 rounded-lg shadow transition transform hover:scale-105 ${
+                      isValid
+                        ? "bg-blue-600 hover:bg-blue-700"
+                        : "bg-blue-400 cursor-not-allowed opacity-50"
+                    }`}
+                  >
+                    Bet/Raise
+                  </button>
+                </div>
+                {!isValid && (
+                  <p className="text-red-500 text-sm">Enter a valid amount ≥ {min}</p>
+                )}
               </div>
             );
           }


### PR DESCRIPTION
## Summary
- sanitize bet amount inputs in `ActionBar` and `ActionPanel`
- clamp bet values before invoking action handlers
- disable bet buttons and show error messages when input is invalid

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68af06a973bc83229e53a7bcbc7c243e