### PR TITLE
feat: use structured cloning for game state

### DIFF
--- a/src/core/models.test.js
+++ b/src/core/models.test.js
@@ -1,0 +1,23 @@
+import { deepClone } from './models';
+
+describe('deepClone', () => {
+  it('copies objects without losing data types', () => {
+    const original = {
+      date: new Date('2024-01-01T00:00:00Z'),
+      map: new Map([[1, { foo: 'bar' }]]),
+      set: new Set([1, 2, 3]),
+      nested: { arr: [1, 2, { a: 3 }] },
+    };
+
+    const copy = deepClone(original);
+
+    expect(copy).not.toBe(original);
+    expect(copy.date instanceof Date).toBe(true);
+    expect(copy.date.getTime()).toBe(original.date.getTime());
+    expect(copy.map instanceof Map).toBe(true);
+    expect(copy.map.get(1)).toEqual({ foo: 'bar' });
+    expect(copy.set instanceof Set).toBe(true);
+    expect(copy.set.has(2)).toBe(true);
+    expect(copy.nested).toEqual(original.nested);
+  });
+});


### PR DESCRIPTION
## Summary
- add `deepClone` helper using `structuredClone` with polyfill fallback
- apply `deepClone` in poker game model
- add tests to ensure cloned state preserves data types

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68af06acaf1083229111913bf1318d2a