### PR TITLE
refactor: extract player builder helper

### DIFF
--- a/src/core/models.js
+++ b/src/core/models.js
@@ -80,6 +80,23 @@ export function deepClone(obj) {
   return clone(obj);
 }
 
+// Build a fresh player state from a template or previous player object
+function buildPlayer(base, deck) {
+  return {
+    name: base.name,
+    isBot: !!base.isBot,
+    level: base.level || "easy",
+    avatar: base.avatar || "/assets/others/dealer.png",
+    chips: base.chips ?? 1000,
+    bet: 0,
+    totalBet: 0,
+    folded: false,
+    hand: [deck.pop(), deck.pop()],
+    lastAction: null,
+    lastActionAmount: 0,
+  };
+}
+
 /**
  * Get next active player's index.
  * @param {Array} players - List of players.
@@ -208,31 +225,11 @@ export default class Game {
     let dealerIndex = this.dealerIndex;
 
     if (!prevState) {
-        players = this.templatePlayers.map((p) => ({
-          name: p.name,
-          isBot: p.isBot,
-          level: p.level,
-          avatar: p.avatar,
-          chips: 1000,
-          bet: 0,
-          totalBet: 0,
-          folded: false,
-          hand: [deck.pop(), deck.pop()],
-          lastAction: null,
-          lastActionAmount: 0,
-        }));
-      dealerIndex = 0;
+        players = this.templatePlayers.map((p) => buildPlayer(p, deck));
+        dealerIndex = 0;
     } else {
-        players = prevState.players.map((p) => ({
-          ...p,
-          bet: 0,
-          totalBet: 0,
-          folded: false,
-          hand: [deck.pop(), deck.pop()],
-          lastAction: null,
-          lastActionAmount: 0,
-        }));
-      dealerIndex = (prevState.dealerIndex + 1) % players.length;
+        players = prevState.players.map((p) => buildPlayer(p, deck));
+        dealerIndex = (prevState.dealerIndex + 1) % players.length;
     }
 
     const smallBlind = 10;


### PR DESCRIPTION
## Summary
- add utility to build player state from template or previous player
- refactor Game.start to use helper and remove duplicate code

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af1d389a708322aff7b8f79e03e2a2