### PR TITLE
refactor: extract player builder helper

### DIFF
--- a/src/core/models.js
+++ b/src/core/models.js
@@ -1,4 +1,5 @@
 // src/core/models.js
+/* global structuredClone */
 import { getWinners as evaluateWinners } from "./handEvaluator";
 
 // Util
@@ -43,8 +44,8 @@ export function deepClone(obj) {
   if (obj === null || obj === undefined) {
     throw new Error("deepClone requires a valid object");
   }
-  if (typeof globalThis.structuredClone === "function") {
-    return globalThis.structuredClone(obj);
+  if (typeof structuredClone === "function") {
+    return structuredClone(obj);
   }
   const seen = new WeakMap();
   const clone = (value) => {
@@ -78,6 +79,23 @@ export function deepClone(obj) {
     return result;
   };
   return clone(obj);
+}
+
+// Build a fresh player state from a template or previous player object
+function buildPlayer(base, deck) {
+  return {
+    name: base.name,
+    isBot: !!base.isBot,
+    level: base.level || "easy",
+    avatar: base.avatar || "/assets/others/dealer.png",
+    chips: base.chips ?? 1000,
+    bet: 0,
+    totalBet: 0,
+    folded: false,
+    hand: [deck.pop(), deck.pop()],
+    lastAction: null,
+    lastActionAmount: 0,
+  };
 }
 
 /**
@@ -208,31 +226,11 @@ export default class Game {
     let dealerIndex = this.dealerIndex;
 
     if (!prevState) {
-        players = this.templatePlayers.map((p) => ({
-          name: p.name,
-          isBot: p.isBot,
-          level: p.level,
-          avatar: p.avatar,
-          chips: 1000,
-          bet: 0,
-          totalBet: 0,
-          folded: false,
-          hand: [deck.pop(), deck.pop()],
-          lastAction: null,
-          lastActionAmount: 0,
-        }));
-      dealerIndex = 0;
+        players = this.templatePlayers.map((p) => buildPlayer(p, deck));
+        dealerIndex = 0;
     } else {
-        players = prevState.players.map((p) => ({
-          ...p,
-          bet: 0,
-          totalBet: 0,
-          folded: false,
-          hand: [deck.pop(), deck.pop()],
-          lastAction: null,
-          lastActionAmount: 0,
-        }));
-      dealerIndex = (prevState.dealerIndex + 1) % players.length;
+        players = prevState.players.map((p) => buildPlayer(p, deck));
+        dealerIndex = (prevState.dealerIndex + 1) % players.length;
     }
 
     const smallBlind = 10;


### PR DESCRIPTION
## Summary
- add utility to build player state from template or previous player
- refactor Game.start to use helper and remove duplicate code
- remove globalThis usage in deepClone to satisfy lint

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af1d389a708322aff7b8f79e03e2a2