### PR TITLE
Improve player customization and table layout

### DIFF
--- a/src/AppDebug.js
+++ b/src/AppDebug.js
@@ -34,21 +34,26 @@ export default function AppDebug() {
     handleAction,
     startNewHand,
     resetGame,
-  } = usePokerEngine([
-    playerConfig || { name: "You", isBot: false, avatar: "/assets/others/avatar2.jpg" },
-    {
-      name: "Lucy",
-      isBot: true,
-      level: "normal",
-      avatar: "/assets/others/avatar1.jpg",
-    },
-    {
-      name: "Carl",
-      isBot: true,
-      level: "hard",
-      avatar: "/assets/others/avatar3.jpg",
-    },
-  ]);
+    } = usePokerEngine(
+      React.useMemo(
+        () => [
+          playerConfig || { name: "You", isBot: false, avatar: "/assets/others/avatar2.jpg" },
+          {
+            name: "Lucy",
+            isBot: true,
+            level: "normal",
+            avatar: "/assets/others/avatar1.jpg",
+          },
+          {
+            name: "Carl",
+            isBot: true,
+            level: "hard",
+            avatar: "/assets/others/avatar3.jpg",
+          },
+        ],
+        [playerConfig]
+      )
+    );
 
   // Suara untuk pemenang
   const playWinnerSound = useSound("/sounds/minecraft_level_up.mp3");
@@ -96,7 +101,7 @@ export default function AppDebug() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
+    <div className="h-screen flex flex-col overflow-hidden bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
       {/* Header */}
       <header className="bg-black/50 backdrop-blur-sm border-b border-gray-700">
         <div className="max-w-7xl mx-auto px-4 py-3">
@@ -124,7 +129,7 @@ export default function AppDebug() {
       </header>
 
       {/* Main game area */}
-      <main className="flex-1">
+      <main className="flex-1 overflow-hidden">
         <PokerTableCompatible 
           state={state} 
           pot={pot} 

--- a/src/AppEnhanced.js
+++ b/src/AppEnhanced.js
@@ -37,21 +37,26 @@ export default function AppEnhanced() {
     sedangBerjalan,
     pemainUtamaHabisChip,
     pemainUtamaMenang,
-  } = usePokerEngineEnhanced([
-    playerConfig || { nama: "You", adalahBot: false, avatar: "/assets/others/avatar2.jpg" },
-    {
-      nama: "Lucy",
-      adalahBot: true,
-      tingkatKesulitan: "normal",
-      avatar: "/assets/others/avatar1.jpg",
-    },
-    {
-      nama: "Carl",
-      adalahBot: true,
-      tingkatKesulitan: "sulit",
-      avatar: "/assets/others/avatar3.jpg",
-    },
-  ]);
+    } = usePokerEngineEnhanced(
+      React.useMemo(
+        () => [
+          playerConfig || { nama: "You", adalahBot: false, avatar: "/assets/others/avatar2.jpg" },
+          {
+            nama: "Lucy",
+            adalahBot: true,
+            tingkatKesulitan: "normal",
+            avatar: "/assets/others/avatar1.jpg",
+          },
+          {
+            nama: "Carl",
+            adalahBot: true,
+            tingkatKesulitan: "sulit",
+            avatar: "/assets/others/avatar3.jpg",
+          },
+        ],
+        [playerConfig]
+      )
+    );
 
   // Suara untuk pemenang
   const mainkanSuaraMenang = useSound("/sounds/minecraft_level_up.mp3");
@@ -87,7 +92,7 @@ export default function AppEnhanced() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
+    <div className="h-screen flex flex-col overflow-hidden bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
       {/* Header */}
       <header className="bg-black/50 backdrop-blur-sm border-b border-gray-700">
         <div className="max-w-7xl mx-auto px-4 py-3">
@@ -115,7 +120,7 @@ export default function AppEnhanced() {
       </header>
 
       {/* Main game area */}
-      <main className="flex-1">
+      <main className="flex-1 overflow-hidden">
         <PokerTableEnhanced 
           state={state} 
           pot={pot} 

--- a/src/components/PlayerSeat.jsx
+++ b/src/components/PlayerSeat.jsx
@@ -63,11 +63,11 @@ export default function PlayerSeat({
     ? "bg-green-600"
     : "bg-blue-600";
   return (
-    <div
-      className={`p-2 min-w-[180px] rounded-xl transition-all duration-300 ease-in-out border border-black shadow-[0_0_0_2px_#fff,0_0_0_4px_#000] bg-black/40 text-gray-100 ${
-        isTurn ? "ring-2 ring-white" : ""
-      } ${round !== "Showdown" && !isTurn ? "opacity-50" : ""}`}
-    >
+      <div
+        className={`p-2 min-w-[200px] rounded-xl transition-all duration-300 ease-in-out border border-black shadow-[0_0_0_2px_#fff,0_0_0_4px_#000] bg-black/40 text-gray-100 ${
+          isTurn ? "ring-2 ring-white" : ""
+        } ${round !== "Showdown" && !isTurn ? "opacity-50" : ""}`}
+      >
       <div className="flex items-center gap-2">
         <label className="relative cursor-pointer">
           <img
@@ -106,10 +106,10 @@ export default function PlayerSeat({
           <span className="text-xs">Bet: {player.taruhanSaatIni}</span>
         )}
       </div>
-      <div className="mt-2 flex gap-3 justify-center">
-        <CardImg card={showFace ? c1 : { back: true }} w={75} />
-        <CardImg card={showFace ? c2 : { back: true }} w={75} />
-      </div>
+        <div className="mt-2 flex gap-3 justify-center">
+          <CardImg card={showFace ? c1 : { back: true }} w={90} />
+          <CardImg card={showFace ? c2 : { back: true }} w={90} />
+        </div>
       {showFace && <div className="mt-1 text-xs text-center">{comboName}</div>}
       <div className="mt-2">
         <div className="h-2 rounded bg-gray-700 overflow-hidden">

--- a/src/components/PlayerSeatEnhanced.jsx
+++ b/src/components/PlayerSeatEnhanced.jsx
@@ -69,7 +69,7 @@ export default function PlayerSeatEnhanced({
     <motion.div
       whileHover={{ scale: adalahGiliran ? 1.02 : 1 }}
       className={`
-        relative p-4 min-w-[200px] rounded-2xl transition-all duration-300 ease-in-out
+        relative p-4 min-w-[220px] rounded-2xl transition-all duration-300 ease-in-out
         border-2 shadow-xl backdrop-blur-sm
         ${adalahGiliran 
           ? "border-yellow-400 shadow-[0_0_20px_rgba(255,215,0,0.5)] bg-gradient-to-br from-yellow-900/30 to-yellow-800/20" 
@@ -188,12 +188,12 @@ export default function PlayerSeatEnhanced({
           whileTap={{ scale: 0.95 }}
           transition={{ type: "spring", stiffness: 300 }}
         >
-          <CardImg 
-            card={tampilkanMuka ? kartu1 : { back: true }} 
-            w={75} 
+          <CardImg
+            card={tampilkanMuka ? kartu1 : { back: true }}
+            w={90}
             className={`transition-all duration-300 transform-gpu ${
-              tampilkanMuka 
-                ? "drop-shadow-2xl hover:drop-shadow-3xl hover:rotate-3" 
+              tampilkanMuka
+                ? "drop-shadow-2xl hover:drop-shadow-3xl hover:rotate-3"
                 : "hover:scale-105"
             }`}
           />
@@ -203,12 +203,12 @@ export default function PlayerSeatEnhanced({
           whileTap={{ scale: 0.95 }}
           transition={{ type: "spring", stiffness: 300 }}
         >
-          <CardImg 
-            card={tampilkanMuka ? kartu2 : { back: true }} 
-            w={75} 
+          <CardImg
+            card={tampilkanMuka ? kartu2 : { back: true }}
+            w={90}
             className={`transition-all duration-300 transform-gpu ${
-              tampilkanMuka 
-                ? "drop-shadow-2xl hover:drop-shadow-3xl hover:-rotate-3" 
+              tampilkanMuka
+                ? "drop-shadow-2xl hover:drop-shadow-3xl hover:-rotate-3"
                 : "hover:scale-105"
             }`}
           />

--- a/src/components/PokerTable.jsx
+++ b/src/components/PokerTable.jsx
@@ -27,14 +27,14 @@ export default function PokerTable({ state, pot, winners }) {
             Pot: <b>{pot}</b>
           </motion.div>
         </div>
-        {/* Community cards */}
-        <div className="flex gap-2 justify-center my-4">
-          {[0, 1, 2, 3, 4].map((i) => (
-            <CardImg key={i} card={community[i]} w={72} />
-          ))}
-        </div>
-        {/* Players layout */}
-        <div className="relative mt-4 h-[220px]">
+          {/* Community cards */}
+          <div className="flex gap-4 justify-center my-4">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <CardImg key={i} card={community[i]} w={100} />
+            ))}
+          </div>
+          {/* Players layout */}
+          <div className="relative mt-4 h-[260px]">
           {/* Player (you) at bottom center */}
           <div className="absolute bottom-0 left-1/2 -translate-x-1/2">
             <PlayerSeat
@@ -51,8 +51,8 @@ export default function PokerTable({ state, pot, winners }) {
             />
           </div>
 
-          {/* Bots on the sides */}
-          <div className="absolute top-0 left-0 flex flex-col gap-4">
+            {/* Bots on the sides */}
+            <div className="absolute left-0 top-1/2 -translate-y-1/2 flex flex-col gap-4">
             {players
               .slice(1, 1 + Math.ceil((players.length - 1) / 2))
               .map((p, idx) => (
@@ -71,7 +71,7 @@ export default function PokerTable({ state, pot, winners }) {
               ))}
           </div>
 
-          <div className="absolute top-0 right-0 flex flex-col gap-4 items-end">
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 flex flex-col gap-4 items-end">
             {players
               .slice(1 + Math.ceil((players.length - 1) / 2))
               .map((p, idx) => (

--- a/src/components/PokerTableCompatible.jsx
+++ b/src/components/PokerTableCompatible.jsx
@@ -43,7 +43,7 @@ export default function PokerTableCompatible({ state, pot, winners }) {
         </div>
 
         {/* Community cards dengan animasi */}
-        <div className="flex justify-center gap-3 my-6 min-h-[100px]">
+        <div className="flex justify-center gap-4 my-6 min-h-[120px]">
           {[0, 1, 2, 3, 4].map((i) => (
             <motion.div
               key={i}
@@ -65,26 +65,26 @@ export default function PokerTableCompatible({ state, pot, winners }) {
               }}
               className="relative"
             >
-              <CardImg 
-                card={community[i]} 
-                w={80} 
-                className={`transition-all duration-300 ${
-                  community[i] 
-                    ? "drop-shadow-lg hover:drop-shadow-xl hover:scale-105" 
-                    : "opacity-50"
-                }`}
-              />
-              {!community[i] && (
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <div className="w-16 h-24 bg-gray-800 border-2 border-dashed border-gray-600 rounded-lg opacity-50"></div>
-                </div>
-              )}
-            </motion.div>
-          ))}
+                <CardImg
+                  card={community[i]}
+                  w={100}
+                  className={`transition-all duration-300 ${
+                    community[i]
+                      ? "drop-shadow-lg hover:drop-shadow-xl hover:scale-105"
+                      : "opacity-50"
+                  }`}
+                />
+                {!community[i] && (
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <div className="w-20 h-28 bg-gray-800 border-2 border-dashed border-gray-600 rounded-lg opacity-50"></div>
+                  </div>
+                )}
+              </motion.div>
+            ))}
         </div>
 
         {/* Players layout */}
-        <div className="relative mt-8 min-h-[280px]">
+        <div className="relative mt-8 min-h-[320px]">
           {/* Player (you) at bottom center */}
           <motion.div
             initial={{ y: 50, opacity: 0 }}
@@ -107,7 +107,7 @@ export default function PokerTableCompatible({ state, pot, winners }) {
           </motion.div>
 
           {/* Bots on the left side */}
-          <div className="absolute top-0 left-0 flex flex-col gap-6">
+          <div className="absolute left-0 top-1/2 -translate-y-1/2 flex flex-col gap-6">
             {players
               .slice(1, 1 + Math.ceil((players.length - 1) / 2))
               .map((p, idx) => (
@@ -133,7 +133,7 @@ export default function PokerTableCompatible({ state, pot, winners }) {
           </div>
 
           {/* Bots on the right side */}
-          <div className="absolute top-0 right-0 flex flex-col gap-6 items-end">
+          <div className="absolute right-0 top-1/2 -translate-y-1/2 flex flex-col gap-6 items-end">
             {players
               .slice(1 + Math.ceil((players.length - 1) / 2))
               .map((p, idx) => (

--- a/src/hooks/usePokerEngine.js
+++ b/src/hooks/usePokerEngine.js
@@ -11,11 +11,20 @@ export default function usePokerEngine(initialPlayers) {
   if (!Array.isArray(initialPlayers)) {
     throw new Error("usePokerEngine requires an array of players");
   }
-  const [game] = useState(() => new Game(initialPlayers));
+
+  // allow game to be recreated when initialPlayers changes (e.g. custom name/avatar)
+  const [game, setGame] = useState(() => new Game(initialPlayers));
 
   // state game
   const [state, setState] = useState(() => game.start());
   const [availableActions, setAvailableActions] = useState([]);
+
+  // reinitialize game and state when player configuration changes
+  useEffect(() => {
+    const newGame = new Game(initialPlayers);
+    setGame(newGame);
+    setState(newGame.start());
+  }, [initialPlayers]);
 
   // derived
   const pot = useMemo(() => game.calculatePot(state), [state, game]);

--- a/src/hooks/usePokerEngineEnhanced.js
+++ b/src/hooks/usePokerEngineEnhanced.js
@@ -11,11 +11,18 @@ export default function usePokerEngineEnhanced(pemainAwal) {
   if (!Array.isArray(pemainAwal)) {
     throw new Error("usePokerEngineEnhanced membutuhkan array pemain");
   }
-  
-  const [game] = useState(() => new GamePoker(pemainAwal));
+
+  // recreate game when player config changes so custom name/avatar apply
+  const [game, setGame] = useState(() => new GamePoker(pemainAwal));
   const [state, setState] = useState(() => game.mulai());
   const [aksiTersedia, setAksiTersedia] = useState([]);
   const [sedangBerjalan, setSedangBerjalan] = useState(false);
+
+  useEffect(() => {
+    const newGame = new GamePoker(pemainAwal);
+    setGame(newGame);
+    setState(newGame.mulai());
+  }, [pemainAwal]);
 
   // State turunan
   const pot = useMemo(() => game.hitungPot(state), [state, game]);


### PR DESCRIPTION
## Summary
- Allow poker engine to reinitialize when player selects custom name and avatar
- Center bot positions and enlarge cards for clearer table layout
- Use full screen layout to avoid scrolling and ensure consistent sizing

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68af9be297c08322b16871e86fd1eafe