### PR TITLE
Improve layout and restore scrolling

### DIFF
--- a/src/AppDebug.js
+++ b/src/AppDebug.js
@@ -101,7 +101,7 @@ export default function AppDebug() {
   }
 
   return (
-    <div className="h-screen flex flex-col overflow-hidden bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
+    <div className="min-h-screen flex flex-col overflow-y-auto bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
       {/* Header */}
       <header className="bg-black/50 backdrop-blur-sm border-b border-gray-700">
         <div className="max-w-7xl mx-auto px-4 py-3">
@@ -129,8 +129,8 @@ export default function AppDebug() {
       </header>
 
       {/* Main game area */}
-      <main className="flex-1 overflow-hidden">
-        <PokerTableCompatible 
+      <main className="flex-1">
+        <PokerTableCompatible
           state={state} 
           pot={pot} 
           winners={winners} 

--- a/src/AppEnhanced.js
+++ b/src/AppEnhanced.js
@@ -92,7 +92,7 @@ export default function AppEnhanced() {
   }
 
   return (
-    <div className="h-screen flex flex-col overflow-hidden bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
+    <div className="min-h-screen flex flex-col overflow-y-auto bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
       {/* Header */}
       <header className="bg-black/50 backdrop-blur-sm border-b border-gray-700">
         <div className="max-w-7xl mx-auto px-4 py-3">
@@ -120,7 +120,7 @@ export default function AppEnhanced() {
       </header>
 
       {/* Main game area */}
-      <main className="flex-1 overflow-hidden">
+      <main className="flex-1">
         <PokerTableEnhanced 
           state={state} 
           pot={pot} 

--- a/src/components/PokerTable.jsx
+++ b/src/components/PokerTable.jsx
@@ -28,13 +28,13 @@ export default function PokerTable({ state, pot, winners }) {
           </motion.div>
         </div>
           {/* Community cards */}
-          <div className="flex gap-4 justify-center my-4">
+          <div className="flex gap-2 justify-center my-2">
             {[0, 1, 2, 3, 4].map((i) => (
               <CardImg key={i} card={community[i]} w={100} />
             ))}
           </div>
           {/* Players layout */}
-          <div className="relative mt-4 h-[260px]">
+          <div className="relative mt-2 h-[220px]">
           {/* Player (you) at bottom center */}
           <div className="absolute bottom-0 left-1/2 -translate-x-1/2">
             <PlayerSeat
@@ -52,7 +52,7 @@ export default function PokerTable({ state, pot, winners }) {
           </div>
 
             {/* Bots on the sides */}
-            <div className="absolute left-0 top-1/2 -translate-y-1/2 flex flex-col gap-4">
+            <div className="absolute left-0 top-1/2 -translate-y-1/2 flex flex-col gap-3">
             {players
               .slice(1, 1 + Math.ceil((players.length - 1) / 2))
               .map((p, idx) => (
@@ -71,7 +71,7 @@ export default function PokerTable({ state, pot, winners }) {
               ))}
           </div>
 
-            <div className="absolute right-0 top-1/2 -translate-y-1/2 flex flex-col gap-4 items-end">
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 flex flex-col gap-3 items-end">
             {players
               .slice(1 + Math.ceil((players.length - 1) / 2))
               .map((p, idx) => (

--- a/src/components/PokerTableCompatible.jsx
+++ b/src/components/PokerTableCompatible.jsx
@@ -11,7 +11,7 @@ export default function PokerTableCompatible({ state, pot, winners }) {
 
   return (
     <div className="p-4">
-      <div className="relative mx-auto max-w-6xl p-6 rounded-[60px] border-4 border-yellow-600 shadow-[0_0_0_6px_#000,0_0_0_12px_#fff,0_0_30px_rgba(255,215,0,0.3)] bg-gradient-to-br from-green-800 via-green-700 to-green-900 text-white font-mono">
+      <div className="relative mx-auto max-w-4xl p-4 rounded-[60px] border-4 border-yellow-600 shadow-[0_0_0_6px_#000,0_0_0_12px_#fff,0_0_30px_rgba(255,215,0,0.3)] bg-gradient-to-br from-green-800 via-green-700 to-green-900 text-white font-mono">
         
         {/* Header info */}
         <div className="flex justify-between items-center mb-6">
@@ -43,7 +43,7 @@ export default function PokerTableCompatible({ state, pot, winners }) {
         </div>
 
         {/* Community cards dengan animasi */}
-        <div className="flex justify-center gap-4 my-6 min-h-[120px]">
+        <div className="flex justify-center gap-3 my-4 min-h-[120px]">
           {[0, 1, 2, 3, 4].map((i) => (
             <motion.div
               key={i}
@@ -84,7 +84,7 @@ export default function PokerTableCompatible({ state, pot, winners }) {
         </div>
 
         {/* Players layout */}
-        <div className="relative mt-8 min-h-[320px]">
+        <div className="relative mt-4 min-h-[260px]">
           {/* Player (you) at bottom center */}
           <motion.div
             initial={{ y: 50, opacity: 0 }}
@@ -107,7 +107,7 @@ export default function PokerTableCompatible({ state, pot, winners }) {
           </motion.div>
 
           {/* Bots on the left side */}
-          <div className="absolute left-0 top-1/2 -translate-y-1/2 flex flex-col gap-6">
+          <div className="absolute left-0 top-1/2 -translate-y-1/2 flex flex-col gap-4">
             {players
               .slice(1, 1 + Math.ceil((players.length - 1) / 2))
               .map((p, idx) => (
@@ -133,7 +133,7 @@ export default function PokerTableCompatible({ state, pot, winners }) {
           </div>
 
           {/* Bots on the right side */}
-          <div className="absolute right-0 top-1/2 -translate-y-1/2 flex flex-col gap-6 items-end">
+          <div className="absolute right-0 top-1/2 -translate-y-1/2 flex flex-col gap-4 items-end">
             {players
               .slice(1 + Math.ceil((players.length - 1) / 2))
               .map((p, idx) => (


### PR DESCRIPTION
## Summary
- restore scroll by removing overflow-hidden usage
- compact poker table spacing while keeping large cards

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afb50cf66883228f9b73bcdcea5a31